### PR TITLE
Decrease max-tokens

### DIFF
--- a/gen_api_answer.py
+++ b/gen_api_answer.py
@@ -112,7 +112,7 @@ if __name__ == "__main__":
     parser.add_argument(
         "--max-tokens",
         type=int,
-        default=32000,
+        default=24000,
         help="The maximum number of new generated tokens.",
     )
     parser.add_argument(


### PR DESCRIPTION
Set 32k tokens for max-tokens for models that support a maximum of 32k tokens in the context window, such as sabiazinho-3) will raise an error, as input + output is larger than 32k.